### PR TITLE
Usermodel relationships

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,25 @@
+import uuid
 import asyncio
-from typing import Optional
+from typing import Optional, List
 
 import pytest
 from fastapi_users import models
+from pydantic import BaseModel, UUID4, Field
+
+
+class Role(BaseModel):
+    id: UUID4 = Field(default_factory=uuid.uuid4)
+    name: str
 
 
 class User(models.BaseUser):
     first_name: Optional[str]
+    roles: Optional[List[Role]]
 
 
 class UserCreate(models.BaseUserCreate):
     first_name: Optional[str]
+    roles: Optional[List[Role]]
 
 
 class UserUpdate(models.BaseUserUpdate):


### PR DESCRIPTION
#### Reference issue:
fastapi-users/fastapi-users#751

This PR aims to allow relationships to be both stored and read on the `User` model, so that relationships may be retrieved on e.g. `GET /me`

This is achieved by minor tweaks on the `create()` and `_get_db_user()` methods respectively, using only code from `ormar` itself.

One test has been added, all tests are passing.

Thank you for your work, I really enjoy using FastAPI-Users!